### PR TITLE
Repository als kanonische Archivstruktur-Spezifikation aufbereiten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Änderungshistorie
+
+Alle bemerkenswerten Änderungen dieser Spezifikation werden hier dokumentiert.
+Format angelehnt an [Keep a Changelog](https://keepachangelog.com/de/1.1.0/).
+
+## [3.0] — 2026-04-18
+
+### Hinzugefügt
+
+- `README.md` mit Überblick über das Repository als Referenzspezifikation.
+- Verzeichnis [reference/](reference/) mit maschinenlesbaren Tabellen
+  (`clubs.csv`, `assets.csv`, `properties.csv`, `abbreviations.csv`) und
+  `patterns.md` mit den regulären Ausdrücken pro Hierarchie-Ebene.
+- Verzeichnis [examples/](examples/) mit Beispielbaum.
+- Asset-Typ `Video` als zulässiger Ordner auf Ebene 1.
+- Eigenschaft `bearbeitet` für nachbearbeitete Dateien.
+- Reservierter Ordnername `Ordnerstruktur` auf Asset-Ebene (wird von
+  Werkzeugen ignoriert).
+
+### Geändert
+
+- `archivstruktur.md` vollständig als sauberes Markdown neu geschrieben
+  (vorher: HTML/CSS-Reste aus Word-Export).
+- Asset-Ebene kanonisch auf `Digitalfoto`, `Ton`, `Video` festgelegt
+  (abgestimmt mit der Referenzimplementierung ligarchivar).
+- Formale Trennung von Pflichtsegmenten (Regex-validiert) und
+  historisch-freien Eigenschaften.
+
+### Entfernt
+
+- Asset-Ordner `Dia` und `Negativ` auf Ebene 1. Materialien dieser Art
+  werden digitalisiert unter `Digitalfoto` geführt.
+
+## [2.3] — 2019-12-20
+
+- Vereinsbuchstabe `R` für Fischerverein hinzugefügt.
+
+## [2.2] — 2015-02-24
+
+- Kapitel für Tiedmann-Bilder erstellt (Status: Entwurf).
+
+## [2.1] — 2012-12-16
+
+- Eigenschaften `LiedNN` und `AUTO` hinzugefügt.
+
+## [2.0] — 2011-12-24
+
+- Umbenennung des Dokuments in `Infos_zu_Archiv.doc`.
+- Ton-Archivstruktur hinzugefügt.
+- Dateinamen-Erweiterung „Eigenschaft“ hinzugefügt.
+
+## [1.2] — 2011-12-10
+
+- Abkürzung `LW` hinzugefügt.
+
+## [1.1] — 2007-12-30
+
+- Beginn der Versionshistorie.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# archivstruktur
+
+Kanonische Definition der Ordner- und Dateistruktur des digitalen Archivs der
+Film-Liga 66 e.V.
+
+Dieses Repository ist die **Referenzspezifikation**. Archivierungs-Werkzeuge
+wie [ligarchivar](https://github.com/filmliga66/ligarchivar) implementieren
+diese Spezifikation und validieren bestehende Archive gegen sie.
+
+## Inhalt
+
+| Pfad                                                         | Zweck                                          |
+| ------------------------------------------------------------ | ---------------------------------------------- |
+| [archivstruktur.md](archivstruktur.md)                       | Menschenlesbare Hauptspezifikation             |
+| [CHANGELOG.md](CHANGELOG.md)                                 | Änderungshistorie der Spezifikation            |
+| [reference/patterns.md](reference/patterns.md)               | Reguläre Ausdrücke pro Hierarchie-Ebene        |
+| [reference/clubs.csv](reference/clubs.csv)                   | Vereine (maschinenlesbar)                      |
+| [reference/assets.csv](reference/assets.csv)                 | Asset-Typen (maschinenlesbar)                  |
+| [reference/properties.csv](reference/properties.csv)         | Datei-Eigenschaften (maschinenlesbar)          |
+| [reference/abbreviations.csv](reference/abbreviations.csv)   | Abkürzungen (maschinenlesbar)                  |
+| [examples/archive-tree.md](examples/archive-tree.md)         | Beispielhafter Archivbaum                      |
+
+## Struktur auf einen Blick
+
+```text
+<root>/
+└── <Asset>/             Digitalfoto | Ton | Video
+    └── <Jahr>/          JJJJ (1700–3000)
+        └── <Verein>/    z. B. F-Film-Liga
+            └── <Event>/ F_JJJJ-MM-TT_Eventname
+                └── F_JJJJ-MM-TT_NNN[_Eigenschaft].ext
+```
+
+Vollständige Regeln in [archivstruktur.md](archivstruktur.md).
+
+## Für Werkzeug-Implementierer
+
+Alle Validierungsregeln lassen sich aus den Regex-Mustern in
+[reference/patterns.md](reference/patterns.md) und den CSV-Tabellen im
+Verzeichnis [reference/](reference/) ableiten. Die CSVs sind UTF-8-kodiert
+und verwenden `,` als Trennzeichen mit Header-Zeile.
+
+Referenzimplementierung: [ligarchivar](https://github.com/filmliga66/ligarchivar)
+(siehe `src/backend/FL.LigArchivar.Core/Data/` und
+`src/backend/FL.LigArchivar.Core/Utilities/Patterns.cs`).
+
+## Beitragen
+
+Änderungen an der Spezifikation werden per Pull Request vorgeschlagen und
+müssen einen Eintrag in [CHANGELOG.md](CHANGELOG.md) enthalten.
+
+## Lizenz
+
+Siehe [LICENSE](LICENSE).

--- a/archivstruktur.md
+++ b/archivstruktur.md
@@ -1,0 +1,210 @@
+# Archivstruktur der Film-Liga
+
+Kanonische Spezifikation der Ordner- und Dateistruktur für das digitale Archiv
+der Film-Liga 66 e.V. Diese Spezifikation ist die Referenzdefinition für
+Archivierungs-Werkzeuge wie [ligarchivar](https://github.com/filmliga66/ligarchivar).
+
+Ergänzende Materialien:
+
+- [CHANGELOG.md](CHANGELOG.md) — Änderungshistorie dieser Spezifikation
+- [reference/patterns.md](reference/patterns.md) — Reguläre Ausdrücke
+- [reference/clubs.csv](reference/clubs.csv) — Vereine maschinenlesbar
+- [reference/assets.csv](reference/assets.csv) — Asset-Typen maschinenlesbar
+- [reference/properties.csv](reference/properties.csv) — Datei-Eigenschaften
+- [reference/abbreviations.csv](reference/abbreviations.csv) — Abkürzungen
+- [examples/archive-tree.md](examples/archive-tree.md) — Beispielbaum
+
+---
+
+## 1. Hierarchie
+
+Das Archiv ist fünfstufig aufgebaut. Jede Ebene hat exakte Namensregeln.
+
+```text
+<Archivwurzel>/
+└── <Asset>/                    Ebene 1 — Medientyp
+    └── <Jahr>/                 Ebene 2 — Vierstelliges Jahr
+        └── <Verein>/           Ebene 3 — Vereinsbuchstabe + Name
+            └── <Event>/        Ebene 4 — Event-Ordner
+                └── <Datei>     Ebene 5 — Mediendatei
+```
+
+## 2. Ebene 1 — Asset
+
+Asset-Ordner auf oberster Ebene. Erlaubt sind genau folgende Namen:
+
+| Name          | Inhalt                          |
+| ------------- | ------------------------------- |
+| `Digitalfoto` | Digitalfotos, digitalisierte Dias und Negative |
+| `Ton`         | Tonaufnahmen                    |
+| `Video`       | Videoaufnahmen                  |
+
+Der Name `Ordnerstruktur` ist für lokale Dokumentation reserviert und wird von
+Werkzeugen ignoriert.
+
+## 3. Ebene 2 — Jahr
+
+Vierstelliges Jahr im Bereich `1700`–`3000`.
+
+Beispiel: `2019`, `2026`.
+
+## 4. Ebene 3 — Verein
+
+Format: `{Buchstabe}-{Vereinsname}`
+
+Der Buchstabe ist ein Großbuchstabe `[A-Z]`. Leerzeichen im Vereinsnamen werden
+durch `_` ersetzt. Erlaubt sind ausschließlich die folgenden Ordner (siehe auch
+[reference/clubs.csv](reference/clubs.csv)):
+
+| Ordnername                    | Bedeutung                         |
+| ----------------------------- | --------------------------------- |
+| `A-Albverein`                 | Albverein                         |
+| `C-Gemischter_Chor`           | Gemischter Chor                   |
+| `D-Dorffest`                  | Dorffest, Dorfgemeinschaft        |
+| `F-Film-Liga`                 | Film-Liga                         |
+| `G-Gemeinde`                  | Gemeinde                          |
+| `H-Hochzeiten`                | Hochzeiten                        |
+| `K-Kirche`                    | Kirche                            |
+| `L-Ledige`                    | Ledige                            |
+| `M-Musikverein`               | Musikverein                       |
+| `N-Narrenzunft`               | Narrenzunft                       |
+| `P-Personen_und_Begebenheiten`| Personen und Begebenheiten        |
+| `R-Fischerverein`             | Fischerverein                     |
+| `S-Schuetzenverein`           | Schützenverein                    |
+| `T-TSV`                       | TSV, Skiclub                      |
+| `V-Ansichten`                 | Ansichten, RumVi                  |
+| `W-Feuerwehr`                 | Feuerwehr                         |
+| `Z-Kegler`                    | Kegler                            |
+
+## 5. Ebene 4 — Event
+
+Format: `{Buchstabe}_{JJJJ}-{MM}-{TT}_{Eventname}`
+
+| Segment       | Regel                                                |
+| ------------- | ---------------------------------------------------- |
+| `Buchstabe`   | Vereinsbuchstabe, `[A-Z]`. Muss zum Elternordner passen. |
+| `JJJJ`        | Jahr, `[12][0-9]{3}`. Muss zum Elternordner passen.  |
+| `MM`          | Monat `00`–`12`. `00` = ganzes Jahr.                 |
+| `TT`          | Tag `00`–`31`. `00` = ganzer Monat.                  |
+| `Eventname`   | `[a-zA-Z0-9\-_]`, 1–200 Zeichen.                     |
+
+Beispiel: `F_2019-07-20_Sommerfest`
+
+## 6. Ebene 5 — Datei
+
+Format: `{Buchstabe}_{JJJJ}-{MM}-{TT}_{NNN}[_{Eigenschaft}].{ext}`
+
+| Segment        | Regel                                                      |
+| -------------- | ---------------------------------------------------------- |
+| `Buchstabe`    | Vereinsbuchstabe, identisch mit Event-Ordner.              |
+| `JJJJ-MM-TT`   | Datum identisch mit Event-Ordner.                          |
+| `NNN`          | Laufende Nummer, genau drei Ziffern.                       |
+| `Eigenschaft`  | Optional. Siehe [Abschnitt 7](#7-eigenschaften).           |
+| `ext`          | Dateiendung entsprechend Format (z. B. `jpg`, `wav`, `mp4`). |
+
+Mehrere Dateien mit identischem Basisnamen (gleicher Nummer) sind erlaubt,
+sofern sich die Dateiendung unterscheidet. Beispiel: `F_2019-07-20_001.jpg`
+und `F_2019-07-20_001.xmp`.
+
+Beispiele:
+
+- `F_2019-07-20_001.jpg`
+- `F_2019-07-20_042_bearbeitet.tif`
+- `M_2012-05-03_015_-6dB.wav`
+
+## 7. Eigenschaften
+
+Die Eigenschaft ist optional und wird mit `_` an die laufende Nummer angehängt.
+Mehrere Eigenschaften werden ohne Trennzeichen aneinander gereiht.
+
+Von Werkzeugen wie ligarchivar erkannte Eigenschaften
+(siehe [reference/properties.csv](reference/properties.csv)):
+
+| Eigenschaft   | Bedeutung                                             |
+| ------------- | ----------------------------------------------------- |
+| `-6dB`        | Dieselbe Tonaufnahme, 6 dB leiser aufgenommen.        |
+| `-12dB`       | Dieselbe Tonaufnahme, 12 dB leiser aufgenommen.       |
+| `bearbeitet`  | Nachbearbeitete Version einer Originaldatei.          |
+
+Weitere, historisch verwendete Eigenschaften (nicht von Werkzeugen interpretiert,
+aber durch den Regex erlaubt):
+
+- `DAT` — von DAT-Kassette
+- `Tonband` — von Tonband
+- `MC` — von Musikkassette
+- `LINE` — zweiter Eingang am Aufnahmegerät (weiterer Kanal)
+- `LiedNN` — Lied Nummer NN aus der Gesamtaufnahme extrahiert
+- `AUTO` — automatisch ausgesteuert
+
+## 8. Zusätzliche Regeln
+
+- **Maximale Länge** von Ordner- und Dateinamen: 50 Zeichen.
+- **Tag `00`** bedeutet: Ereignis verteilt über den ganzen Monat (oder mehrere
+  Folgemonate). Die Dateien im Verzeichnis tragen ebenfalls Tag `00`, damit
+  keine Dateinamen-Kollisionen entstehen.
+- **Textdateien** mit Erklärungen und Zusatzinformationen tragen den Namen
+  ihres Ordners.
+- **Ereignis über 24 Uhr hinaus**: Datum des vorigen Tages verwenden. Ausnahme:
+  mehrtägige Veranstaltungen.
+
+## 9. Bewertung in Adobe Bridge
+
+Bildbewertung für `Digitalfoto`:
+
+| Sterne | Bedeutung                           |
+| ------ | ----------------------------------- |
+| 1      | Sehr schlechtes Bild, gerade noch im Archiv |
+| 2      | Schlechtes Bild                     |
+| 3      | Bild ist in Ordnung                 |
+| 4      | Gutes Bild                          |
+| 5      | Besonderes Bild                     |
+
+## 10. Abkürzungen
+
+Abkürzungen sind Konstanten und werden großgeschrieben. Siehe auch
+[reference/abbreviations.csv](reference/abbreviations.csv).
+
+| Abkürzung | Bedeutung                                                     |
+| --------- | ------------------------------------------------------------- |
+| `NNJ`     | NN Jahre (z. B. `60J`)                                        |
+| `FL`      | Film-Liga                                                     |
+| `GC`      | Gemischter Chor                                               |
+| `GS`      | Grundschule                                                   |
+| `PGR`     | Pfarrgemeinderat                                              |
+| `GEB`     | Geburtstag                                                    |
+| `GV`      | Generalversammlung                                            |
+| `SSE`     | Seelsorgeeinheit                                              |
+| `KIFE`    | Kinderferienprogramm                                          |
+| `KLJB`    | Katholischer Landjugendbund                                   |
+| `NT`      | Narrentreffen                                                 |
+| `ORAT`    | Ortschaftsrat                                                 |
+| `BMG`     | Bürgermeister Gombold                                         |
+| `JUGU`    | Jugend-Gruppe                                                 |
+| `LW`      | Landwirtschaft (innerhalb Personen und Begebenheiten)         |
+| `WUERT`   | Württemberg, württembergisch                                  |
+
+## 11. Tiedmann-Negative
+
+Historische Negativsammlung Tiedmann, separat geführt.
+
+### 11.1 Negativnummer
+
+Format: `{Ordner}-{Blatt}-{Streifen}-{Nummer}`
+
+| Segment   | Regel                                                       |
+| --------- | ----------------------------------------------------------- |
+| `Ordner`  | Römisch nummeriert, z. B. `X`, `XVIII`.                     |
+| `Blatt`   | Zweistellig, z. B. `12`.                                    |
+| `Streifen`| Einstellig, `1`–`7`.                                        |
+| `Nummer`  | Bildnummer auf dem Streifen, z. B. `2`, `15a`, `23`.        |
+
+### 11.2 Dateiname
+
+Format: `{Kategorie}_{Sortierung}_{Negativnummer}_{Auflösung}`
+
+| Segment         | Regel                                                    |
+| --------------- | -------------------------------------------------------- |
+| `Kategorie`     | Vereinsbuchstabe analog zu Abschnitt 4 (in Definition).  |
+| `Sortierung`    | Vierstellige Nummer für grobe zeitliche Sortierung.      |
+| `Negativnummer` | Siehe 11.1.                                              |
+| `Auflösung`     | Scanauflösung, z. B. `Vorschau`, `Hoch`, `Nachbearbeitet` (in Definition). |

--- a/examples/archive-tree.md
+++ b/examples/archive-tree.md
@@ -1,0 +1,51 @@
+# Beispielhafter Archivbaum
+
+Fiktiver, aber vollständig regelkonformer Ausschnitt eines Archivs. Illustriert
+alle fünf Hierarchie-Ebenen sowie typische Sonderfälle.
+
+```text
+archiv/
+├── Digitalfoto/
+│   ├── Ordnerstruktur/                       (reservierter, ignorierter Ordner)
+│   │   └── archivstruktur.md
+│   ├── 2019/
+│   │   ├── F-Film-Liga/
+│   │   │   └── F_2019-07-20_Sommerfest/
+│   │   │       ├── F_2019-07-20_001.jpg
+│   │   │       ├── F_2019-07-20_002.jpg
+│   │   │       ├── F_2019-07-20_003.jpg
+│   │   │       └── F_2019-07-20_003_bearbeitet.tif
+│   │   └── M-Musikverein/
+│   │       └── M_2019-05-00_Probenwoche/     (Tag 00 = ganzer Monat)
+│   │           ├── M_2019-05-00_001.jpg
+│   │           └── M_2019-05-00_002.jpg
+│   └── 2026/
+│       └── N-Narrenzunft/
+│           └── N_2026-02-08_Narrentreffen/
+│               ├── N_2026-02-08_001.jpg
+│               └── N_2026-02-08_002.jpg
+├── Ton/
+│   └── 2012/
+│       └── M-Musikverein/
+│           └── M_2012-05-03_Fruehjahrskonzert/
+│               ├── M_2012-05-03_001.wav
+│               ├── M_2012-05-03_001_-6dB.wav
+│               └── M_2012-05-03_001_-12dB.wav
+└── Video/
+    └── 2026/
+        └── F-Film-Liga/
+            └── F_2026-04-18_GV/
+                ├── F_2026-04-18_001.mp4
+                └── F_2026-04-18_002.mp4
+```
+
+## Erläuterungen
+
+- `Ordnerstruktur/` auf Asset-Ebene ist für lokale Dokumentation reserviert und
+  wird von Werkzeugen ignoriert.
+- `M_2019-05-00_Probenwoche`: Tag `00` bedeutet, die Veranstaltung verteilt sich
+  über den gesamten Mai. Dateien tragen ebenfalls Tag `00`.
+- `F_2019-07-20_003.jpg` und `F_2019-07-20_003_bearbeitet.tif` demonstrieren
+  Original und nachbearbeitete Fassung.
+- `M_2012-05-03_001_-6dB.wav` zeigt dieselbe Tonaufnahme in gedämpfter
+  Aufnahmeaussteuerung.

--- a/reference/abbreviations.csv
+++ b/reference/abbreviations.csv
@@ -1,0 +1,17 @@
+abbreviation,meaning
+NNJ,NN Jahre (z. B. 60J)
+FL,Film-Liga
+GC,Gemischter Chor
+GS,Grundschule
+PGR,Pfarrgemeinderat
+GEB,Geburtstag
+GV,Generalversammlung
+SSE,Seelsorgeeinheit
+KIFE,Kinderferienprogramm
+KLJB,Katholischer Landjugendbund
+NT,Narrentreffen
+ORAT,Ortschaftsrat
+BMG,Bürgermeister Gombold
+JUGU,Jugend-Gruppe
+LW,Landwirtschaft (bei Personen und Begebenheiten)
+WUERT,Württemberg/Württembergisch

--- a/reference/assets.csv
+++ b/reference/assets.csv
@@ -1,0 +1,4 @@
+folder,description
+Digitalfoto,Digitalfotos sowie digitalisierte Dias und Negative
+Ton,Tonaufnahmen
+Video,Videoaufnahmen

--- a/reference/clubs.csv
+++ b/reference/clubs.csv
@@ -1,0 +1,18 @@
+letter,folder,name,notes
+A,A-Albverein,Albverein,
+C,C-Gemischter_Chor,Gemischter Chor,
+D,D-Dorffest,Dorffest,Dorfgemeinschaft
+F,F-Film-Liga,Film-Liga,
+G,G-Gemeinde,Gemeinde,
+H,H-Hochzeiten,Hochzeiten,
+K,K-Kirche,Kirche,
+L,L-Ledige,Ledige,
+M,M-Musikverein,Musikverein,
+N,N-Narrenzunft,Narrenzunft,
+P,P-Personen_und_Begebenheiten,Personen und Begebenheiten,
+R,R-Fischerverein,Fischerverein,
+S,S-Schuetzenverein,Schuetzenverein,
+T,T-TSV,TSV,Skiclub
+V,V-Ansichten,Ansichten,RumVi
+W,W-Feuerwehr,Feuerwehr,
+Z,Z-Kegler,Kegler,

--- a/reference/patterns.md
+++ b/reference/patterns.md
@@ -1,0 +1,58 @@
+# Reguläre Ausdrücke
+
+Formale Validierungsregeln der Archivstruktur. Die Muster entsprechen exakt
+denen der Referenzimplementierung
+[ligarchivar](https://github.com/filmliga66/ligarchivar)
+(`src/backend/FL.LigArchivar.Core/Utilities/Patterns.cs`).
+
+## Bausteine
+
+| Baustein     | Regex                       | Beschreibung                              |
+| ------------ | --------------------------- | ----------------------------------------- |
+| `ClubPart`   | `([A-Z])`                   | Vereinsbuchstabe, ein Großbuchstabe.      |
+| `YearPart`   | `([12][0-9]{3})`            | Jahr, 1000–2999.                          |
+| `MonthPart`  | `(0[0-9]\|1[0-2])`          | Monat, `00`–`12`.                         |
+| `DayPart`    | `(0[0-9]\|[12][0-9]\|3[01])`| Tag, `00`–`31`.                           |
+| `EventName`  | `([a-zA-Z0-9\-_]{1,200})`   | Eventname, 1–200 Zeichen.                 |
+| `NumberPart` | `([0-9]{3})`                | Laufende Nummer, exakt drei Ziffern.      |
+| `Property`   | `([a-zA-Z0-9\-_]{1,200})`   | Dateieigenschaft, 1–200 Zeichen.          |
+
+## Zusammengesetzte Muster
+
+### Event-Ordner
+
+```regex
+([A-Z])_([12][0-9]{3})-(0[0-9]|1[0-2])-(0[0-9]|[12][0-9]|3[01])_([a-zA-Z0-9\-_]{1,200})
+```
+
+Gruppen: `1` = Verein, `2` = Jahr, `3` = Monat, `4` = Tag, `5` = Eventname.
+
+Beispiel: `F_2019-07-20_Sommerfest`
+
+### Dateiname (ohne Endung)
+
+```regex
+([A-Z])_([12][0-9]{3})-(0[0-9]|1[0-2])-(0[0-9]|[12][0-9]|3[01])_([0-9]{3})(_([a-zA-Z0-9\-_]{1,200}))?
+```
+
+Gruppen: `1` = Verein, `2` = Jahr, `3` = Monat, `4` = Tag, `5` = Nummer,
+`7` = Eigenschaft (optional).
+
+Beispiele:
+
+- `F_2019-07-20_001`
+- `F_2019-07-20_042_bearbeitet`
+- `M_2012-05-03_015_-6dB`
+
+## Zusätzliche strukturelle Einschränkungen
+
+Diese werden nicht durch die Regex allein geprüft, sondern durch die
+Werkzeug-Logik:
+
+- **Asset-Ordner** auf Ebene 1: Name muss in [assets.csv](assets.csv) stehen.
+- **Jahr-Ordner** auf Ebene 2: 1700 ≤ Jahr ≤ 3000.
+- **Vereins-Ordner** auf Ebene 3: Name muss exakt in [clubs.csv](clubs.csv) stehen.
+- **Event-Ordner**: Vereinsbuchstabe und Jahr müssen zum Pfad passen (Eltern-
+  Vereinsordner und Eltern-Jahr-Ordner).
+- **Dateien**: Vereinsbuchstabe und Datum müssen mit dem Event-Ordner
+  übereinstimmen.

--- a/reference/properties.csv
+++ b/reference/properties.csv
@@ -1,0 +1,10 @@
+property,recognized_by_tools,description
+-6dB,true,Dieselbe Tonaufnahme 6 dB leiser aufgenommen
+-12dB,true,Dieselbe Tonaufnahme 12 dB leiser aufgenommen
+bearbeitet,true,Nachbearbeitete Version einer Originaldatei
+DAT,false,Quelle DAT-Kassette (historisch)
+Tonband,false,Quelle Tonband (historisch)
+MC,false,Quelle Musikkassette (historisch)
+LINE,false,Zweiter Aufnahmekanal (historisch)
+LiedNN,false,Lied Nummer NN aus der Gesamtaufnahme extrahiert (historisch)
+AUTO,false,Automatisch ausgesteuert (historisch)


### PR DESCRIPTION
## Zusammenfassung

- `archivstruktur.md` vollständig in sauberem Markdown neu verfasst (vorher: HTML/CSS-Reste aus Word-Export).
- Inhaltlich mit der Referenzimplementierung [ligarchivar](https://github.com/filmliga66/ligarchivar) abgeglichen:
  - Asset-Ebene kanonisch auf `Digitalfoto` / `Ton` / `Video` (ligarchivar `AssetDirectory.cs`); `Dia` und `Negativ` entfernt, `Video` ergänzt.
  - Club-Liste, Regex-Muster und Property-Liste 1:1 gespiegelt (`ClubDirectory.cs`, `Patterns.cs`, `DataFile.cs`).
  - Reservierter Ordnername `Ordnerstruktur` auf Asset-Ebene dokumentiert.
- Maschinenlesbare Referenzen unter `reference/`: `clubs.csv`, `assets.csv`, `properties.csv`, `abbreviations.csv`, `patterns.md`.
- Beispielbaum unter `examples/archive-tree.md`.
- `README.md` als Einstieg; `CHANGELOG.md` übernimmt die bisherige Änderungshistorie und dokumentiert Version 3.0.

## Ergebnis

Das Repository ist jetzt eine verbindliche, maschinen- **und** menschenlesbare Definition der Archivstruktur und kann als Vorlage für Werkzeuge wie ligarchivar verwendet werden.

## Test plan

- [ ] Dateinamen in `clubs.csv` manuell mit `ClubDirectory.AllowedNames` in ligarchivar abgleichen.
- [ ] Regex-Muster in `reference/patterns.md` gegen `Patterns.cs` in ligarchivar abgleichen.
- [ ] `archivstruktur.md` gerendert auf GitHub auf Lesbarkeit prüfen.
- [ ] Sicherstellen, dass alle relativen Links in `README.md` und `archivstruktur.md` funktionieren.